### PR TITLE
Remove MySQL specific implementation.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,14 +17,6 @@ class socat ( $param='' ) {
 		content => template('socat/socat.erb'),
 	}
 
-	file { '/var/run/mysqld':
-		ensure => directory,
-		owner  => nobody,
-		group  => daemon,
-		mode   => 755,
-		before => Service['socat'],
-	}
-
 	service { 'socat':
 		ensure    => running,
 		enable    => true,


### PR DESCRIPTION
Thanks for putting this together!  It was helpful.  Unfortunately, /var/run/mysqld isn't really a good place to ensure a directory though, because it gets deleted when the box is restarted unless the MySQL server is actually present.  I ended up moving my mysql sock to /tmp to avoid any restart issues. 
