### PR TITLE
Multiple instances configurable, puppet 5 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,26 +1,35 @@
-class socat ( $param='' ) {
-	package { 'socat':
-		ensure => installed,
-	}
+# params is a hash of socat instances to run
+#  {
+#    'name1' => 'command line args',
+#    'name2' => 'command line args',
+#  }
+class socat ( $params={} ) {
+  package { 'socat':
+    ensure => installed,
+  }
 
-	file { '/etc/init.d/socat':
-		source => 'puppet:///modules/socat/socat',
-		require => Package['socat'],
-		notify  => Service['socat'],
-		owner   => root, group => root, mode => 0750;
-	}
+  File{
+    owner => 'root',
+    group => 'root',
+  }
 
-	file { '/etc/default/socat':
-		owner   => root,
-		group   => root,
-		mode    => 664,
-		content => template('socat/socat.erb'),
-	}
+  file { '/etc/init.d/socat':
+    source => 'puppet:///modules/socat/socat',
+    require => Package['socat'],
+    notify  => Service['socat'],
+    mode => "0750";
+  }
 
-	service { 'socat':
-		ensure    => running,
-		enable    => true,
-		hasstatus => true,
-		require   => Package['socat'],
-	}
+  file { '/etc/default/socat':
+    mode    => "664",
+    content => template('socat/socat.erb'),
+    notify  => Service['socat'],
+  }
+
+  service { 'socat':
+    ensure    => running,
+    enable    => true,
+    hasstatus => true,
+    require   => Package['socat'],
+  }
 }

--- a/templates/socat.erb
+++ b/templates/socat.erb
@@ -1,7 +1,5 @@
-AUTOSTART=default
- 
-<% if has_variable?("param") -%>
-SOCAT_default="<%= param %>"
-<% else -%>
-SOCAT_default=""
+AUTOSTART="<%=@params.keys.join ' '%>"
+
+<% @params.each do |name, param|%>
+SOCAT_<%=name%>="<%= param %>"
 <% end -%>


### PR DESCRIPTION
The init script supported multiple socat instances, but there was no way to configure them using this module.