### PR TITLE
Add INIT info for update-rc.d

### DIFF
--- a/files/socat
+++ b/files/socat
@@ -2,6 +2,15 @@
 #
 # socat         Startup script for the socat
 #
+### BEGIN INIT INFO
+# Provides:          socat
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Starts socat tunnels 
+# Description:       Starts all socat tunnels specified in /etc/default/socat
+### END INIT INFO
 #
  
 NAME=socat


### PR DESCRIPTION
Adds runlevel specifications so that puppet (via update-rc.d) can enable this service.

This makes it compatible with Ubuntu 18 (worked without this in Ubuntu 14, I haven't tested others).